### PR TITLE
feat: Introduce word quiz mode and mode selection UI

### DIFF
--- a/tamil.py
+++ b/tamil.py
@@ -50,9 +50,21 @@ for base_char, base_pron in all_consonants.items():
 TAMIL_CHARACTERS.append(('ஸ்ரீ', 'sri'))
 # --- ここまで文字生成 ---
 
+TAMIL_WORDS = [
+    ('வணக்கம்', 'vaṇakkam'),  # Hello
+    ('நன்றி', 'naṉṟi'),      # Thank you
+    ('தமிழ்', 'tamiḻ'),      # Tamil
+    ('காலை', 'kālai'),      # Morning
+    ('மாலை', 'mālai'),      # Evening
+    ('பழம்', 'paḻam'),       # Fruit
+    ('தண்ணீர்', 'taṇṇīr'),   # Water
+    ('சோறு', 'sōṟu'),        # Rice (cooked)
+    ('பூ', 'pū'),           # Flower
+    ('வீடு', 'vīṭu')         # House
+]
 
-# --- Helper function to get next character ---
-def _get_next_character(session_state, all_chars):
+# --- Helper function to get next item ---
+def _get_next_item(session_state, all_chars):
     if not session_state.remaining_characters:
         if session_state.used_characters:
             # Repopulate from used_characters
@@ -97,63 +109,89 @@ html, body, [class*="st-"] {
 """, unsafe_allow_html=True)
 # --- フォント読み込みここまで ---
 
+# --- Initialize quiz_mode before setting title ---
+if 'quiz_mode' not in st.session_state:
+    st.session_state.quiz_mode = "文字" # Default to Characters
 
-st.title('タミル文字 読み方練習')
+# --- Set title based on quiz_mode ---
+if st.session_state.quiz_mode == "文字":
+    st.title('タミル文字 読み方練習')
+else: # "単語"
+    st.title('タミル単語 読み方練習')
+
+# --- Mode selection ---
+# Note: The radio button will now correctly reflect the initialized quiz_mode
+st.session_state.quiz_mode = st.radio(
+    "練習モードを選択:",
+    ("文字", "単語"),
+    index=0 if st.session_state.quiz_mode == "文字" else 1, # Set default selection
+    key='quiz_mode_radio' # Add a key for stability if needed elsewhere
+)
 
 # --- セッション状態管理 ---
-if 'remaining_characters' not in st.session_state:
-    st.session_state.remaining_characters = TAMIL_CHARACTERS.copy()
+# Function to initialize or reset lists based on quiz_mode
+def initialize_lists():
+    if st.session_state.quiz_mode == "文字":
+        source_list = TAMIL_CHARACTERS
+    else: # "単語"
+        source_list = TAMIL_WORDS
+
+    st.session_state.remaining_characters = source_list.copy()
     random.shuffle(st.session_state.remaining_characters)
     st.session_state.used_characters = []
 
-if 'current_char_data' not in st.session_state:
-    next_char_tuple = _get_next_character(st.session_state, TAMIL_CHARACTERS)
-    if next_char_tuple:
-        st.session_state.current_char_data = next_char_tuple
+    next_item = _get_next_item(st.session_state, source_list)
+    if next_item:
+        st.session_state.current_char_data = next_item
         st.session_state.show_answer = False
     else:
-        # Handle case where no character could be retrieved (e.g., TAMIL_CHARACTERS is empty)
-        st.error("タミル文字のリストが初期状態で空です。")
-        st.session_state.current_char_data = (None, "エラー") # Default to prevent crash
-        st.session_state.show_answer = False # Or True to show the error message if needed
+        st.error(f"{st.session_state.quiz_mode}のリストが空です。")
+        st.session_state.current_char_data = (None, "エラー")
+        st.session_state.show_answer = False
 
-character, pronunciation = st.session_state.current_char_data if st.session_state.current_char_data else (" ", " ")
+# Check if quiz_mode has changed or if it's the first run for list initialization
+if 'previous_quiz_mode' not in st.session_state:
+    st.session_state.previous_quiz_mode = st.session_state.quiz_mode # Initialize on first run
+    initialize_lists()
+elif st.session_state.previous_quiz_mode != st.session_state.quiz_mode:
+    st.session_state.previous_quiz_mode = st.session_state.quiz_mode # Update mode
+    initialize_lists() # Re-initialize lists and fetch new item
+elif 'current_char_data' not in st.session_state: # Ensure current_char_data is always initialized
+    initialize_lists()
+
+
+item_text, item_pronunciation = st.session_state.current_char_data if st.session_state.current_char_data else (" ", " ")
 
 st.divider()
 
-# 1. タミル文字を表示 (CSSクラスを適用)
-# Ensure character is not None before trying to display it
-if character:
-    st.markdown(f"<div class='tamil-char-display'>{character}</div>", unsafe_allow_html=True)
+# 1. タミル文字/単語を表示 (CSSクラスを適用)
+# Ensure item_text is not None before trying to display it
+if item_text:
+    st.markdown(f"<div class='tamil-char-display'>{item_text}</div>", unsafe_allow_html=True)
 else:
     st.markdown(f"<div class='tamil-char-display'> </div>", unsafe_allow_html=True) # Show empty space
-    st.warning("表示する文字がありません。")
+    st.warning(f"表示する{st.session_state.quiz_mode}がありません。")
 
 
 # --- ボタンと回答表示 ---
 col1, col2 = st.columns(2)
 with col1:
-    if st.button('回答を見る', key=f'show_{character if character else "no_char_show"}'): # Handle None character
+    if st.button('回答を見る', key=f'show_{st.session_state.quiz_mode}_{item_text if item_text else "no_item_show"}'):
         st.session_state.show_answer = True
 with col2:
-    if st.button('次へ', key=f'next_{character if character else "no_char_next"}'): # Handle None character
-        next_char_tuple = _get_next_character(st.session_state, TAMIL_CHARACTERS)
-        if next_char_tuple:
-            st.session_state.current_char_data = next_char_tuple
+    if st.button('次へ', key=f'next_{st.session_state.quiz_mode}_{item_text if item_text else "no_item_next"}'):
+        current_list = TAMIL_CHARACTERS if st.session_state.quiz_mode == "文字" else TAMIL_WORDS
+        next_item = _get_next_item(st.session_state, current_list)
+        if next_item:
+            st.session_state.current_char_data = next_item
+            st.session_state.show_answer = False
         else:
-            # This case implies TAMIL_CHARACTERS might be empty or an issue in _get_next_character
-            st.error("次の文字を取得できませんでした。リストの終端か、リストが空の可能性があります。")
-            # Optionally, try to reset or display a message
-            # For now, keep current_char_data as is or set to an error state if desired
-            # st.session_state.current_char_data = (None, "エラー") # Avoid if causes reruns issues
-
-        st.session_state.show_answer = False
+            st.error(f"次の{st.session_state.quiz_mode}を取得できませんでした。リストの終端か、リストが空の可能性があります。")
+            # Keep current_char_data or set to an error/empty state
         st.rerun()
 
 if st.session_state.show_answer:
-    # 回答のフォントもNoto Sans Tamilになるようにする（全体適用していれば不要かも）
-    if character: # Only show pronunciation if there's a character
-        st.success(f'読み: **{pronunciation}**')
-    # else: it might show "読み: エラー" or "読み:  " depending on default, or hide it
+    if item_text: # Only show pronunciation if there's an item
+        st.success(f'読み: **{item_pronunciation}**')
 
 st.divider()

--- a/tamil.py
+++ b/tamil.py
@@ -64,23 +64,23 @@ TAMIL_WORDS = [
 ]
 
 # --- Helper function to get next item ---
-def _get_next_item(session_state, all_chars):
+def _get_next_item(session_state, all_items):
     if not session_state.remaining_characters:
         if session_state.used_characters:
             # Repopulate from used_characters
             session_state.remaining_characters = session_state.used_characters.copy()
             random.shuffle(session_state.remaining_characters)
             session_state.used_characters = []
-        elif all_chars: # used_characters is empty, but all_chars is available
-            session_state.remaining_characters = all_chars.copy()
+        elif all_items: # used_characters is empty, but all_items is available
+            session_state.remaining_characters = all_items.copy()
             random.shuffle(session_state.remaining_characters)
             session_state.used_characters = []
         else:
-            # No characters in used_characters and no all_chars provided (or all_chars is empty)
+            # No characters in used_characters and no all_items provided (or all_items is empty)
             return None
 
     if not session_state.remaining_characters:
-        # If still empty after trying to repopulate (e.g. all_chars was empty initially)
+        # If still empty after trying to repopulate (e.g. all_items was empty initially)
         return None
 
     next_char_tuple = session_state.remaining_characters.pop(0)
@@ -142,11 +142,11 @@ def initialize_lists():
 
     next_item = _get_next_item(st.session_state, source_list)
     if next_item:
-        st.session_state.current_char_data = next_item
+        st.session_state.current_item_data = next_item
         st.session_state.show_answer = False
     else:
         st.error(f"{st.session_state.quiz_mode}のリストが空です。")
-        st.session_state.current_char_data = (None, "エラー")
+        st.session_state.current_item_data = (None, "エラー")
         st.session_state.show_answer = False
 
 # Check if quiz_mode has changed or if it's the first run for list initialization
@@ -156,11 +156,11 @@ if 'previous_quiz_mode' not in st.session_state:
 elif st.session_state.previous_quiz_mode != st.session_state.quiz_mode:
     st.session_state.previous_quiz_mode = st.session_state.quiz_mode # Update mode
     initialize_lists() # Re-initialize lists and fetch new item
-elif 'current_char_data' not in st.session_state: # Ensure current_char_data is always initialized
+elif 'current_item_data' not in st.session_state: # Ensure current_item_data is always initialized
     initialize_lists()
 
 
-item_text, item_pronunciation = st.session_state.current_char_data if st.session_state.current_char_data else (" ", " ")
+item_text, item_pronunciation = st.session_state.current_item_data
 
 st.divider()
 
@@ -183,11 +183,11 @@ with col2:
         current_list = TAMIL_CHARACTERS if st.session_state.quiz_mode == "文字" else TAMIL_WORDS
         next_item = _get_next_item(st.session_state, current_list)
         if next_item:
-            st.session_state.current_char_data = next_item
+            st.session_state.current_item_data = next_item
             st.session_state.show_answer = False
         else:
             st.error(f"次の{st.session_state.quiz_mode}を取得できませんでした。リストの終端か、リストが空の可能性があります。")
-            # Keep current_char_data or set to an error/empty state
+            # Keep current_item_data or set to an error/empty state
         st.rerun()
 
 if st.session_state.show_answer:


### PR DESCRIPTION


This commit extends the Tamil learning application to include words as quiz subjects, in addition to the existing character quizzes.

Key changes:
- Added a `TAMIL_WORDS` list containing Tamil words and their pronunciations.
- Implemented a radio button UI for you to select between "Character" (文字) and "Word" (単語) quiz modes.
- Modified session state management to dynamically load and manage the appropriate list (characters or words) based on the selected mode.
- Renamed the core item fetching function from `_get_next_character` to `_get_next_item` for generality.
- Updated UI variable names (e.g., `character` to `item_text`) to better reflect that they can hold either characters or words.
- Made the application title dynamic, changing between "タミル文字 読み方練習" and "タミル単語 読み方練習" based on the active mode.

The application now provides a more versatile learning experience by allowing you to practice reading both individual Tamil characters and complete words.